### PR TITLE
Don't call getWrappedConnection in factory

### DIFF
--- a/DBAL/TracingEventListener.php
+++ b/DBAL/TracingEventListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auxmoney\OpentracingDoctrineDBALBundle\DBAL;
+
+use Auxmoney\OpentracingBundle\Service\Tracing;
+use Doctrine\DBAL\Event\ConnectionEventArgs;
+use ReflectionException;
+use ReflectionObject;
+
+final class TracingEventListener
+{
+    private $tracing;
+    private $spanFactory;
+
+    public function __construct(
+        Tracing $tracing,
+        SpanFactory $spanFactory
+    ) {
+        $this->tracing = $tracing;
+        $this->spanFactory = $spanFactory;
+    }
+
+    /**
+     * @param ConnectionEventArgs $args
+     * @throws ReflectionException
+     */
+    public function postConnect(ConnectionEventArgs $args): void
+    {
+        $connection = $args->getConnection();
+        $reflectionObject = new ReflectionObject($connection);
+        $property = $reflectionObject->getProperty('_conn');
+        $property->setAccessible(true);
+        $previousConnection = $property->getValue($connection);
+        $driverConnection = new TracingDriverConnection(
+            $previousConnection,
+            $this->tracing,
+            $this->spanFactory,
+            $connection->getUsername()
+        );
+        $property->setValue($connection, $driverConnection);
+        $property->setAccessible(false);
+    }
+}

--- a/Tests/DBAL/TracingConnectionFactoryTest.php
+++ b/Tests/DBAL/TracingConnectionFactoryTest.php
@@ -10,7 +10,6 @@ use Auxmoney\OpentracingDoctrineDBALBundle\DBAL\TracingConnectionFactory;
 use Auxmoney\OpentracingDoctrineDBALBundle\DBAL\TracingDriverConnection;
 use Doctrine\Bundle\DoctrineBundle\ConnectionFactory as DoctrineConnectionFactory;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver;
 use PHPUnit\Framework\TestCase;
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": "^7.1.33",
     "ext-json": "*",
-    "auxmoney/opentracing-bundle-core": "^0.4",
+    "auxmoney/opentracing-bundle-core": "^0.5",
     "opentracing/opentracing": "1.0.0-beta5@beta",
     "doctrine/doctrine-bundle": "^1.11|^2.0",
     "doctrine/dbal": "^2.6"


### PR DESCRIPTION
Should solve #8.

Instead of calling `$connection->getWrappedConnection()` in the connection factory, we register an event listener that will be notified after the `connect()` method is called.

This way we will override the driver connection only after it has been initiated.
