### PR TITLE
fix: broken interfaces from 2.6

### DIFF
--- a/DBAL/TracingStatement.php
+++ b/DBAL/TracingStatement.php
@@ -97,7 +97,7 @@ final class TracingStatement implements IteratorAggregate, Statement, WrappingSt
     /**
      * @inheritDoc
      */
-    public function bindValue($param, $value, $type = null)
+    public function bindValue($param, $value, $type = 2 /* Doctrine\DBAL\ParameterType::STRING */)
     {
         $this->params[$param] = $value;
         return $this->statement->bindValue($param, $value, $type);
@@ -106,7 +106,7 @@ final class TracingStatement implements IteratorAggregate, Statement, WrappingSt
     /**
      * @inheritDoc
      */
-    public function bindParam($column, &$variable, $type = null, $length = null)
+    public function bindParam($column, &$variable, $type = 2 /* Doctrine\DBAL\ParameterType::STRING */, $length = null)
     {
         return $this->statement->bindParam($column, $variable, $type, $length);
     }

--- a/Tests/Functional/FunctionalTest.dbal-prepared-statements.expected.yaml
+++ b/Tests/Functional/FunctionalTest.dbal-prepared-statements.expected.yaml
@@ -50,6 +50,15 @@ children:
         key: db.parameters
         value: '[]'
   -
+    operationName: 'DBAL: SELECT test_table'
+    tags:
+      -
+        key: db.statement
+        value: 'SELECT str FROM test_table WHERE str = ?'
+      -
+        key: db.parameters
+        value: '{"1":"a"}'
+  -
     operationName: 'DBAL: UPDATE test_table'
     tags:
       -

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -26,7 +26,7 @@ class FunctionalTest extends JaegerFunctionalTest
     {
         $this->setupTestProjectDbal($project, $withORM);
 
-        $this->assertSpans('dbal-prepared-statements', 11);
+        $this->assertSpans('dbal-prepared-statements', 12);
     }
 
     /**

--- a/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestPreparedStatementsCommand.php
@@ -42,6 +42,9 @@ class TestPreparedStatementsCommand extends Command
         $selectCount->execute();
         Assert::eq($selectCount->fetchColumn(), 2);
 
+        $result = $this->connection->executeQuery('SELECT str FROM test_table WHERE str = ?', ['a']);
+        Assert::eq($result->fetchColumn(), 'a');
+
         Assert::eq($this->connection->executeUpdate('UPDATE test_table SET str = :new WHERE str = :original', ['new' => null, 'original' => 'a']), 1);
         $selectCount->execute();
         Assert::eq($selectCount->fetchColumn(), 1);

--- a/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestPreparedStatementsCommand.php
@@ -44,6 +44,9 @@ class TestPreparedStatementsCommand extends Command
         $selectCount->execute();
         Assert::eq($selectCount->fetchColumn(), 2);
 
+        $result = $this->connection->executeQuery('SELECT str FROM test_table WHERE str = ?', ['a']);
+        Assert::eq($result->fetchColumn(), 'a');
+
         Assert::eq($this->connection->executeUpdate('UPDATE test_table SET str = :new WHERE str = :original', ['new' => null, 'original' => 'a']), 1);
         $selectCount->execute();
         Assert::eq($selectCount->fetchColumn(), 1);

--- a/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestPreparedStatementsCommand.php
@@ -57,7 +57,7 @@ class TestPreparedStatementsCommand extends Command
 
         Assert::eq($this->connection->exec('UPDATE test_table SET str = NULL WHERE str IS NOT NULL'), 0);
         Assert::eq($this->connection->getInsertCount(), 0);
-        Assert::eq($this->connection->getExecuteQueryCount(), 1);
+        Assert::eq($this->connection->getExecuteQueryCount(), 2);
 
         $carrier = [];
         $this->opentracing->getTracerInstance()->inject($this->opentracing->getTracerInstance()->getActiveSpan()->getContext(), TEXT_MAP, $carrier);

--- a/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestPreparedStatementsCommand.php
@@ -42,6 +42,9 @@ class TestPreparedStatementsCommand extends Command
         $selectCount->execute();
         Assert::eq($selectCount->fetchColumn(), 2);
 
+        $result = $this->connection->executeQuery('SELECT str FROM test_table WHERE str = ?', ['a']);
+        Assert::eq($result->fetchColumn(), 'a');
+
         Assert::eq($this->connection->executeUpdate('UPDATE test_table SET str = :new WHERE str = :original', ['new' => null, 'original' => 'a']), 1);
         $selectCount->execute();
         Assert::eq($selectCount->fetchColumn(), 1);

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "auxmoney/opentracing-bundle-core": "^0.6",
     "opentracing/opentracing": "1.0.0-beta5@beta",
     "doctrine/doctrine-bundle": "^1.11|^2.0",
-    "doctrine/dbal": "^2.6"
+    "doctrine/dbal": "^2.7"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",


### PR DESCRIPTION
closes #15 

This PR provides:
* new test cases for reproduction (e.g. [travis logs](https://travis-ci.org/github/auxmoney/OpentracingBundle-Doctrine-DBAL/jobs/693741283#L686))
* upgrade to at least `doctrine/dbal` version `2.7`
* fixes for wrong signatures