### PR TITLE
new 7 methods from Doctrine\DBAL\Abstraction\Result are implemented in TracingStatement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,15 +19,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: '7.1'
+          - php: '7.3'
             symfony: '3.4.*'
           - php: '7.4'
             symfony: '3.4.*'
-          - php: '7.2'
+          - php: '7.3'
             symfony: '4.4.*'
           - php: '7.4'
             symfony: '4.4.*'
-          - php: '7.2'
+          - php: '7.3'
             symfony: '5.1.*'
           - php: '7.4'
             symfony: '5.1.*'

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /.php-version
 /build/
 /vendor/
+.idea/

--- a/DBAL/StatementCombinedResult.php
+++ b/DBAL/StatementCombinedResult.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auxmoney\OpentracingDoctrineDBALBundle\DBAL;
+
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+
+interface StatementCombinedResult extends Statement, Result
+{
+
+}

--- a/DBAL/TracingStatement.php
+++ b/DBAL/TracingStatement.php
@@ -11,7 +11,7 @@ use IteratorAggregate;
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
  * @implements IteratorAggregate<Statement>
  */
-final class TracingStatement implements IteratorAggregate, Statement, WrappingStatement
+final class TracingStatement implements IteratorAggregate, StatementCombinedResult, WrappingStatement
 {
     /**
      * @var Statement<Statement>
@@ -163,5 +163,61 @@ final class TracingStatement implements IteratorAggregate, Statement, WrappingSt
     public function getWrappedStatement(): Statement
     {
         return $this->statement;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAllAssociative(): array
+    {
+        return $this->statement->fetchAllAssociative();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchNumeric()
+    {
+        return $this->statement->fetchNumeric();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAssociative()
+    {
+        return $this->statement->fetchAssociative();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchOne()
+    {
+        return $this->statement->fetchOne();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchAllNumeric(): array
+    {
+        return $this->statement->fetchAllNumeric();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fetchFirstColumn(): array
+    {
+        return $this->statement->fetchFirstColumn();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function free(): void
+    {
+        $this->statement->free();
     }
 }

--- a/Tests/Functional/FunctionalTest.dbal-connection-api.expected.yaml
+++ b/Tests/Functional/FunctionalTest.dbal-connection-api.expected.yaml
@@ -44,6 +44,18 @@ children:
         key: db.statement
         value: 'SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'
   -
+    operationName: 'DBAL: SELECT test_table'
+    tags:
+      -
+        key: auxmoney-opentracing-bundle.span-origin
+        value: 'DBAL:select'
+      -
+        key: db.parameters
+        value: '[]'
+      -
+        key: db.statement
+        value: 'SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'
+  -
     operationName: 'DBAL: INSERT INTO test_table'
     tags:
       -
@@ -68,6 +80,18 @@ children:
         key: db.statement
         value: 'SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'
   -
+    operationName: 'DBAL: SELECT test_table'
+    tags:
+      -
+        key: auxmoney-opentracing-bundle.span-origin
+        value: 'DBAL:select'
+      -
+        key: db.parameters
+        value: '[]'
+      -
+        key: db.statement
+        value: 'SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'
+  -
     operationName: 'DBAL: UPDATE test_table'
     tags:
       -
@@ -79,6 +103,18 @@ children:
       -
         key: db.statement
         value: 'UPDATE test_table SET str = ? WHERE str = ?'
+  -
+    operationName: 'DBAL: SELECT test_table'
+    tags:
+      -
+        key: auxmoney-opentracing-bundle.span-origin
+        value: 'DBAL:select'
+      -
+        key: db.parameters
+        value: '[]'
+      -
+        key: db.statement
+        value: 'SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'
   -
     operationName: 'DBAL: SELECT test_table'
     tags:

--- a/Tests/Functional/FunctionalTest.dbal-prepared-statements.expected.yaml
+++ b/Tests/Functional/FunctionalTest.dbal-prepared-statements.expected.yaml
@@ -44,6 +44,30 @@ children:
         key: db.statement
         value: 'SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'
   -
+    operationName: 'DBAL: SELECT test_table'
+    tags:
+      -
+        key: auxmoney-opentracing-bundle.span-origin
+        value: 'DBAL:select'
+      -
+        key: db.parameters
+        value: '[]'
+      -
+        key: db.statement
+        value: 'SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'
+  -
+    operationName: 'DBAL: SELECT test_table'
+    tags:
+      -
+        key: auxmoney-opentracing-bundle.span-origin
+        value: 'DBAL:select'
+      -
+        key: db.parameters
+        value: '[]'
+      -
+        key: db.statement
+        value: 'SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'
+  -
     operationName: 'DBAL: INSERT INTO test_table'
     tags:
       -

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -26,7 +26,7 @@ class FunctionalTest extends JaegerConsoleFunctionalTest
     {
         $this->setupTestProjectDbal($project, $withORM);
 
-        $this->assertSpans('dbal-prepared-statements', 12);
+        $this->assertSpans('dbal-prepared-statements', 14);
     }
 
     /**

--- a/Tests/Functional/FunctionalTest.php
+++ b/Tests/Functional/FunctionalTest.php
@@ -16,7 +16,7 @@ class FunctionalTest extends JaegerConsoleFunctionalTest
     {
         $this->setupTestProjectDbal($project, $withORM);
 
-        $this->assertSpans('dbal-connection-api', 12);
+        $this->assertSpans('dbal-connection-api', 15);
     }
 
     /**

--- a/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestConnectionAPICommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestConnectionAPICommand.php
@@ -32,12 +32,15 @@ class TestConnectionAPICommand extends Command
 
         Assert::eq($this->connection->insert('test_table', ['str' => 'a'], [ParameterType::STRING]), 1);
         Assert::eq($this->connection->fetchAll('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0]['COUNT(*)'], 1);
+        Assert::eq($this->connection->fetchAllAssociative('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0]['COUNT(*)'], 1);
 
         Assert::eq($this->connection->insert('test_table', ['str' => 'b'], [ParameterType::STRING]), 1);
         Assert::eq($this->connection->fetchColumn('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'), 2);
+        Assert::eq($this->connection->fetchOne('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'), 2);
 
         Assert::eq($this->connection->update('test_table', ['str' => null], ['str' => 'a'], [ParameterType::STRING, ParameterType::STRING]), 1);
         Assert::eq($this->connection->fetchArray('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0][0], 1);
+        Assert::eq($this->connection->fetchAllNumeric('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0][0], 1);
 
         $id = $this->connection->executeQuery('SELECT id FROM test_table WHERE str IS NOT NULL')->fetchColumn();
         Assert::eq($this->connection->delete('test_table', ['id' => $id], [ParameterType::INTEGER]), 1);

--- a/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestPreparedStatementsCommand.php
@@ -29,8 +29,6 @@ class TestPreparedStatementsCommand extends Command
     {
         $selectCount = $this->connection->executeQuery('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL');
         Assert::eq($selectCount->fetch()['COUNT(*)'], 0);
-        Assert::eq($selectCount->fetchAssociative()['COUNT(*)'], 0);
-        Assert::eq($selectCount->fetchNumeric()[0], 0);
 
         $insert = $this->connection->prepare('INSERT INTO test_table VALUES (null, :str)');
 
@@ -38,6 +36,12 @@ class TestPreparedStatementsCommand extends Command
         Assert::eq($insert->rowCount(), 1);
         $selectCount->execute();
         Assert::eq($selectCount->fetchAll()[0]['COUNT(*)'], 1);
+        $selectCount->free();
+        $selectCount->execute();
+        Assert::eq($selectCount->fetchAssociative()['COUNT(*)'], 1);
+        $selectCount->free();
+        $selectCount->execute();
+        Assert::eq($selectCount->fetchNumeric()[0], 1);
 
         $insert->execute(['str' => 'b']);
         Assert::eq($insert->rowCount(), 1);

--- a/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestPreparedStatementsCommand.php
@@ -29,6 +29,8 @@ class TestPreparedStatementsCommand extends Command
     {
         $selectCount = $this->connection->executeQuery('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL');
         Assert::eq($selectCount->fetch()['COUNT(*)'], 0);
+        Assert::eq($selectCount->fetchAssociative()['COUNT(*)'], 0);
+        Assert::eq($selectCount->fetchNumeric()[0], 0);
 
         $insert = $this->connection->prepare('INSERT INTO test_table VALUES (null, :str)');
 

--- a/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestQueryBuilderCommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-standard/src/Command/TestQueryBuilderCommand.php
@@ -65,7 +65,7 @@ class TestQueryBuilderCommand extends Command
             ->where('id = :id')
             ->setParameter('id', $id);
         Assert::eq($deleteBuilder->execute(), 1);
-        Assert::eq($selectBuilder->execute()->fetchColumn(), 0);
+        Assert::eq($selectBuilder->execute()->fetchOne(), 0);
 
         Assert::eq($this->connection->exec('UPDATE test_table SET str = NULL WHERE str IS NOT NULL'), 0);
 

--- a/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestConnectionAPICommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestConnectionAPICommand.php
@@ -34,12 +34,15 @@ class TestConnectionAPICommand extends Command
 
         Assert::eq($this->connection->insert('test_table', ['str' => 'a'], [ParameterType::STRING]), 1);
         Assert::eq($this->connection->fetchAll('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0]['COUNT(*)'], 1);
+        Assert::eq($this->connection->fetchAllAssociative('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0]['COUNT(*)'], 1);
 
         Assert::eq($this->connection->insert('test_table', ['str' => 'b'], [ParameterType::STRING]), 1);
         Assert::eq($this->connection->fetchColumn('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'), 2);
+        Assert::eq($this->connection->fetchOne('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'), 2);
 
         Assert::eq($this->connection->update('test_table', ['str' => null], ['str' => 'a'], [ParameterType::STRING, ParameterType::STRING]), 1);
         Assert::eq($this->connection->fetchArray('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0][0], 1);
+        Assert::eq($this->connection->fetchAllNumeric('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0][0], 1);
 
         $id = $this->connection->executeQuery('SELECT id FROM test_table WHERE str IS NOT NULL')->fetchColumn();
         Assert::eq($this->connection->delete('test_table', ['id' => $id], [ParameterType::INTEGER]), 1);
@@ -47,7 +50,7 @@ class TestConnectionAPICommand extends Command
 
         Assert::eq($this->connection->exec('UPDATE test_table SET str = NULL WHERE str IS NOT NULL'), 0);
         Assert::eq($this->connection->getInsertCount(), 2);
-        Assert::eq($this->connection->getExecuteQueryCount(), 6);
+        Assert::eq($this->connection->getExecuteQueryCount(), 9);
 
         $carrier = [];
         $this->opentracing->getTracerInstance()->inject($this->opentracing->getTracerInstance()->getActiveSpan()->getContext(), TEXT_MAP, $carrier);

--- a/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestPreparedStatementsCommand.php
@@ -31,8 +31,6 @@ class TestPreparedStatementsCommand extends Command
         Assert::isInstanceOf($this->connection, TestWrapper::class);
         $selectCount = $this->connection->executeQuery('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL');
         Assert::eq($selectCount->fetch()['COUNT(*)'], 0);
-        Assert::eq($selectCount->fetchAssociative()['COUNT(*)'], 0);
-        Assert::eq($selectCount->fetchNumeric()[0], 0);
 
         $insert = $this->connection->prepare('INSERT INTO test_table VALUES (null, :str)');
 
@@ -40,6 +38,13 @@ class TestPreparedStatementsCommand extends Command
         Assert::eq($insert->rowCount(), 1);
         $selectCount->execute();
         Assert::eq($selectCount->fetchAll()[0]['COUNT(*)'], 1);
+        $selectCount->free();
+        $selectCount->execute();
+        Assert::eq($selectCount->fetchAssociative()['COUNT(*)'], 1);
+        $selectCount->free();
+        $selectCount->execute();
+        Assert::eq($selectCount->fetchNumeric()[0], 1);
+
 
         $insert->execute(['str' => 'b']);
         Assert::eq($insert->rowCount(), 1);

--- a/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestPreparedStatementsCommand.php
@@ -31,6 +31,8 @@ class TestPreparedStatementsCommand extends Command
         Assert::isInstanceOf($this->connection, TestWrapper::class);
         $selectCount = $this->connection->executeQuery('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL');
         Assert::eq($selectCount->fetch()['COUNT(*)'], 0);
+        Assert::eq($selectCount->fetchAssociative()['COUNT(*)'], 0);
+        Assert::eq($selectCount->fetchNumeric()[0], 0);
 
         $insert = $this->connection->prepare('INSERT INTO test_table VALUES (null, :str)');
 

--- a/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestQueryBuilderCommand.php
+++ b/Tests/Functional/TestProjectFiles/dbal-wrapper/src/Command/TestQueryBuilderCommand.php
@@ -67,7 +67,7 @@ class TestQueryBuilderCommand extends Command
             ->where('id = :id')
             ->setParameter('id', $id);
         Assert::eq($deleteBuilder->execute(), 1);
-        Assert::eq($selectBuilder->execute()->fetchColumn(), 0);
+        Assert::eq($selectBuilder->execute()->fetchOne(), 0);
 
         Assert::eq($this->connection->exec('UPDATE test_table SET str = NULL WHERE str IS NOT NULL'), 0);
         Assert::eq($this->connection->getInsertCount(), 0);

--- a/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestConnectionAPICommand.php
+++ b/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestConnectionAPICommand.php
@@ -32,12 +32,15 @@ class TestConnectionAPICommand extends Command
 
         Assert::eq($this->connection->insert('test_table', ['str' => 'a'], [ParameterType::STRING]), 1);
         Assert::eq($this->connection->fetchAll('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0]['COUNT(*)'], 1);
+        Assert::eq($this->connection->fetchAllAssociative('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0]['COUNT(*)'], 1);
 
         Assert::eq($this->connection->insert('test_table', ['str' => 'b'], [ParameterType::STRING]), 1);
         Assert::eq($this->connection->fetchColumn('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'), 2);
+        Assert::eq($this->connection->fetchOne('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL'), 2);
 
         Assert::eq($this->connection->update('test_table', ['str' => null], ['str' => 'a'], [ParameterType::STRING, ParameterType::STRING]), 1);
         Assert::eq($this->connection->fetchArray('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0][0], 1);
+        Assert::eq($this->connection->fetchAllNumeric('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL')[0][0], 1);
 
         $id = $this->connection->executeQuery('SELECT id FROM test_table WHERE str IS NOT NULL')->fetchColumn();
         Assert::eq($this->connection->delete('test_table', ['id' => $id], [ParameterType::INTEGER]), 1);

--- a/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestPreparedStatementsCommand.php
@@ -29,8 +29,6 @@ class TestPreparedStatementsCommand extends Command
     {
         $selectCount = $this->connection->executeQuery('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL');
         Assert::eq($selectCount->fetch()['COUNT(*)'], 0);
-        Assert::eq($selectCount->fetchAssociative()['COUNT(*)'], 0);
-        Assert::eq($selectCount->fetchNumeric()[0], 0);
 
         $insert = $this->connection->prepare('INSERT INTO test_table VALUES (null, :str)');
 
@@ -38,6 +36,12 @@ class TestPreparedStatementsCommand extends Command
         Assert::eq($insert->rowCount(), 1);
         $selectCount->execute();
         Assert::eq($selectCount->fetchAll()[0]['COUNT(*)'], 1);
+        $selectCount->free();
+        $selectCount->execute();
+        Assert::eq($selectCount->fetchAssociative()['COUNT(*)'], 1);
+        $selectCount->free();
+        $selectCount->execute();
+        Assert::eq($selectCount->fetchNumeric()[0], 1);
 
         $insert->execute(['str' => 'b']);
         Assert::eq($insert->rowCount(), 1);

--- a/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestPreparedStatementsCommand.php
+++ b/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestPreparedStatementsCommand.php
@@ -29,6 +29,8 @@ class TestPreparedStatementsCommand extends Command
     {
         $selectCount = $this->connection->executeQuery('SELECT COUNT(*) FROM test_table WHERE str IS NOT NULL');
         Assert::eq($selectCount->fetch()['COUNT(*)'], 0);
+        Assert::eq($selectCount->fetchAssociative()['COUNT(*)'], 0);
+        Assert::eq($selectCount->fetchNumeric()[0], 0);
 
         $insert = $this->connection->prepare('INSERT INTO test_table VALUES (null, :str)');
 

--- a/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestQueryBuilderCommand.php
+++ b/Tests/Functional/TestProjectFiles/orm-em/src/Command/TestQueryBuilderCommand.php
@@ -65,7 +65,7 @@ class TestQueryBuilderCommand extends Command
             ->where('id = :id')
             ->setParameter('id', $id);
         Assert::eq($deleteBuilder->execute(), 1);
-        Assert::eq($selectBuilder->execute()->fetchColumn(), 0);
+        Assert::eq($selectBuilder->execute()->fetchOne(), 0);
 
         Assert::eq($this->connection->exec('UPDATE test_table SET str = NULL WHERE str IS NOT NULL'), 0);
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "auxmoney/opentracing-bundle-core": "^0.7.1",
     "opentracing/opentracing": "1.0.0-beta5@beta",
     "doctrine/doctrine-bundle": "^1.11|^2.0",
-    "doctrine/dbal": "^2.7"
+    "doctrine/dbal": "^2.11"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,3 +14,10 @@ parameters:
     # target methods: beginTransaction(), commit(), rollBack()
     - message: '/Else branch is unreachable because ternary operator condition is always true./'
       path: '%currentWorkingDirectory%/DBAL/TracingDriverConnection.php'
+    # necessary, because  Doctrine\DBAL\Statement implements 2 interfaces in the same time
+    # Doctrine\DBAL\Driver\Statement and Doctrine\DBAL\Abstraction\Result
+    # but Doctrine\DBAL\Driver\Connection::prepare and Doctrine\DBAL\Driver\Connection::query returns only Doctrine\DBAL\Driver\Statement
+    # target methods: fetchAllAssociative(), fetchNumeric(), fetchAssociative(), fetchOne(),
+    # fetchAllNumeric(), fetchFirstColumn(), free()
+    - message: '/Call to an undefined method [a-zA-Z0-9\\_\&\<\>]+::(fetchAllAssociative|fetchNumeric|fetchAssociative|fetchOne|fetchAllNumeric|fetchFirstColumn|free)\(\)/'
+      path: '%currentWorkingDirectory%/DBAL/TracingStatement.php'


### PR DESCRIPTION
From `2.11` version `doctrine/dbal` implements `Doctrine\DBAL\Statement` `Doctrine\DBAL\Driver\Statement` and `Doctrine\DBAL\Abstraction\Result`. In `Doctrine\DBAL\Driver\Result` there are new 7 methods, that `Doctrine\DBAL\Statement` implements. However, there is no interface, that collects these 2 interfaces. In this commit, it solves with new `StatementCombinedResult` interface.